### PR TITLE
Fix incorrect URL - binary-file.md

### DIFF
--- a/src/administration-guide/installation/binary-file.md
+++ b/src/administration-guide/installation/binary-file.md
@@ -62,7 +62,7 @@ Semaphore will be available via the following URL [https://localhost:3000](https
 
 ### Run as a service
 
-For more detailed information &mdash; look into the [extended Systemd service documentation](./installation_manually.md#extended-systemd-service).
+For more detailed information &mdash; look into the [extended Systemd service documentation](../installation_manually.md#extended-systemd-service).
 
 If you installed Semaphore via a package manager, or by downloading a binary file, you should create the Semaphore service manually.
 


### PR DESCRIPTION
404 Not Found
Code: NoSuchKey
Message: The specified key does not exist.