### PR TITLE
Fix incorrect URL - snap.md

### DIFF
--- a/src/administration-guide/installation/snap.md
+++ b/src/administration-guide/installation/snap.md
@@ -46,6 +46,6 @@ After installation, you can set up Semaphore via [Snap Configuration](https://sn
 sudo snap get semaphore
 ```
 
-&#x20;List of available options you can find in [Configuration options reference](./configuration#configuration-options).
+&#x20;List of available options you can find in [Configuration options reference](../configuration.md#configuration-options).
 
 ----


### PR DESCRIPTION
404 Not Found
Code: NoSuchKey
Message: The specified key does not exist.