### PR TITLE
Add Pocket-ID OpenID configuration guide

### DIFF
--- a/src/administration-guide/openid.md
+++ b/src/administration-guide/openid.md
@@ -13,6 +13,7 @@ Links:
 * [Okta config](./openid/okta.md)
 * [Azure config](./openid/azure.md)
 * [Zitadel config](./openid/zitadel.md)
+* [Pocket-ID config](./openid/pocket-id.md)
 
 Example of SSO provider configuration:
 

--- a/src/administration-guide/openid/pocket-id.md
+++ b/src/administration-guide/openid/pocket-id.md
@@ -1,0 +1,28 @@
+<div class="breadcrumbs">
+    <a href="/administration-guide/openid">OpenID</a>
+    → GitLab config
+</div>
+
+# Pocket-ID config
+
+`config.json`:
+```json
+"oidc_providers": {
+    "pocketid": {
+        "display_name": "Sign in with PocketID",
+        "provider_url": "https://<your-pocket-id-url>",
+        "client_id": "<client-id-from-pocket-id>",
+        "client_secret": "<client-secret-from-pocket-id>",
+        "redirect_url": "https://<your-semaphore-ui-url>/api/auth/oidc/pocketid/redirect/",
+        "scopes": [
+            "openid",
+            "profile",
+            "email"
+        ],
+        "username_claim": "email",
+        "name_claim": "given_name"
+    }
+}
+```
+
+Info is also on Pocket-ID Site under Client Examples: [Pocket-ID Client Examples - Semaphore UI](https://pocket-id.org/docs/client-examples/semaphore-ui/).


### PR DESCRIPTION
Added documentation for configuring Pocket-ID as an OpenID provider, including a sample config and reference link. Updated the OpenID index to include Pocket-ID in the list of provider guides.