### PR TITLE
fix: incorrect URL

### DIFF
--- a/src/user-guide/task-templates/README.md
+++ b/src/user-guide/task-templates/README.md
@@ -2,11 +2,11 @@
 
 Templates define how to run Semaphore tasks. Currently the following task types are supported:
 
-* [Ansible](./ansible.md)
-* [Terraform/OpenTofu](./terraform.md)
-* [Shell](./bash.md)
-* [Powershell](./powershell.md)
-* [Python](./python.md)
+* [Ansible](./apps/ansible.md)
+* [Terraform/OpenTofu](./apps/terraform.md)
+* [Shell](./apps/bash.md)
+* [Powershell](./apps/powershell.md)
+* [Python](./apps/python.md)
 
 ---
 


### PR DESCRIPTION
From the [Task Templates](https://docs.semaphoreui.com/user-guide/task-templates/#task-templates) page, the links are broken