### PR TITLE
Document git clone behaviour.

### DIFF
--- a/docs/user-guide/tasks.md
+++ b/docs/user-guide/tasks.md
@@ -1,6 +1,8 @@
 # Tasks
 
-A task is an instance of launching an Ansible playbook. You can create the task from [Task Template](task-templates/) by clicking the button Run/Build/Deploy for the required template.
+A task is an instance of launching a template task. You can create the task from [Task Template](task-templates/) by clicking the button Run/Build/Deploy for the required template.
+
+Each task has an independent copy of the complete repository to ensure read consistency.
 
 ![](/assets/image6.png)
 


### PR DESCRIPTION
Each task instance seems to clone the Git repository. It might be that it is per task template (which might cause problems on read consistency), but unable to reproduce that.