### PR TITLE
[codex] Fix PingFederate placeholders and TLS redirect docs

### DIFF
--- a/docs/admin-guide/openid/pingfederate.md
+++ b/docs/admin-guide/openid/pingfederate.md
@@ -22,4 +22,9 @@
 }
 ```
 
-Replace `YOUR_ENVIRONMENT_ID` with the PingOne environment identifier from your issuer URL.
+Replace the placeholders with values from your PingFederate configuration:
+
+* `YOUR_CLIENT_ID` — the OIDC application client ID.
+* `YOUR_CLIENT_SECRET` — the OIDC application client secret.
+* `YOUR_SEMAPHORE_HOST_AND_PORT` — the external Semaphore UI host and port.
+* `YOUR_ENVIRONMENT_ID` — the environment identifier from your issuer URL.

--- a/docs/admin-guide/security/network.md
+++ b/docs/admin-guide/security/network.md
@@ -50,7 +50,8 @@ TLS configuration options:
 | `tls.enabled` | `SEMAPHORE_TLS_ENABLED` | Enables HTTPS for the Semaphore server. |
 | `tls.cert_file` | `SEMAPHORE_TLS_CERT_FILE` | Path to the TLS certificate file. |
 | `tls.key_file` | `SEMAPHORE_TLS_KEY_FILE` | Path to the TLS private key file. |
-| `tls.http_redirect_addr` | `SEMAPHORE_TLS_HTTP_REDIRECT_ADDR` | Optional address for the HTTP-to-HTTPS redirect listener, for example `80`. This is mutually exclusive with `tls.http_redirect_port`. |
+| `tls.http_redirect_addr` | `SEMAPHORE_TLS_HTTP_REDIRECT_ADDR` | Address (`host[:port]`) for the HTTP-to-HTTPS redirect listener. Mutually exclusive with `tls.http_redirect_port`. |
+| `tls.http_redirect_port` | `SEMAPHORE_TLS_HTTP_REDIRECT_PORT` | Port to redirect HTTP traffic to HTTPS. Mutually exclusive with `tls.http_redirect_addr`. |
 
 Alternatively, you can use a reverse proxy in front of Semaphore to handle secure connections. For example:
 

--- a/docs/admin-guide/security/network.md
+++ b/docs/admin-guide/security/network.md
@@ -28,7 +28,7 @@ Semaphore supports SSL/TLS starting from v2.12.
         "enabled": true,
         "cert_file": "/path/to/cert/example.com.cert",
         "key_file": "/path/to/key/example.com.key",
-        "http_redirect_addr": ":80"
+        "http_redirect_addr": "80"
     }
     ...
 }
@@ -40,7 +40,7 @@ Or environment variables (useful for Docker):
 export SEMAPHORE_TLS_ENABLED=True
 export SEMAPHORE_TLS_CERT_FILE=/path/to/cert/example.com.cert
 export SEMAPHORE_TLS_KEY_FILE=/path/to/key/example.com.key
-export SEMAPHORE_TLS_HTTP_REDIRECT_ADDR=:80
+export SEMAPHORE_TLS_HTTP_REDIRECT_ADDR=80
 ```
 
 TLS configuration options:
@@ -50,7 +50,7 @@ TLS configuration options:
 | `tls.enabled` | `SEMAPHORE_TLS_ENABLED` | Enables HTTPS for the Semaphore server. |
 | `tls.cert_file` | `SEMAPHORE_TLS_CERT_FILE` | Path to the TLS certificate file. |
 | `tls.key_file` | `SEMAPHORE_TLS_KEY_FILE` | Path to the TLS private key file. |
-| `tls.http_redirect_addr` | `SEMAPHORE_TLS_HTTP_REDIRECT_ADDR` | Optional address for the HTTP-to-HTTPS redirect listener, for example `:80` or `0.0.0.0:80`. This is mutually exclusive with `tls.http_redirect_port`. |
+| `tls.http_redirect_addr` | `SEMAPHORE_TLS_HTTP_REDIRECT_ADDR` | Optional address for the HTTP-to-HTTPS redirect listener, for example `80`. This is mutually exclusive with `tls.http_redirect_port`. |
 
 Alternatively, you can use a reverse proxy in front of Semaphore to handle secure connections. For example:
 

--- a/docs/admin-guide/security/network.md
+++ b/docs/admin-guide/security/network.md
@@ -27,23 +27,7 @@ Semaphore supports SSL/TLS starting from v2.12.
     "tls": {
         "enabled": true,
         "cert_file": "/path/to/cert/example.com.cert",
-        "key_file": "/path/to/key/example.com.key",
-        "http_redirect_addr": "80"
-    }
-    ...
-}
-```
-
-or:
-
-```json
-{
-    ...
-    "tls": {
-        "enabled": true,
-        "cert_file": "/path/to/cert/example.com.cert",
-        "key_file": "/path/to/key/example.com.key",
-        "http_redirect_port": 80
+        "key_file": "/path/to/key/example.com.key"
     }
     ...
 }
@@ -55,27 +39,20 @@ Or environment variables (useful for Docker):
 export SEMAPHORE_TLS_ENABLED=True
 export SEMAPHORE_TLS_CERT_FILE=/path/to/cert/example.com.cert
 export SEMAPHORE_TLS_KEY_FILE=/path/to/key/example.com.key
-export SEMAPHORE_TLS_HTTP_REDIRECT_ADDR=80
 ```
 
-or:
+### HTTP-to-HTTPS redirect listener
 
-```bash
-export SEMAPHORE_TLS_ENABLED=True
-export SEMAPHORE_TLS_CERT_FILE=/path/to/cert/example.com.cert
-export SEMAPHORE_TLS_KEY_FILE=/path/to/key/example.com.key
-export SEMAPHORE_TLS_HTTP_REDIRECT_PORT=80
-```
+To configure the HTTP-to-HTTPS redirect listener, add one of the following fields to the `tls` block in `config.json`, or set the corresponding environment variable.
 
-TLS configuration options:
+Use `http_redirect_addr` to bind the listener to a specific IP address and port. Use `http_redirect_port` to listen on all network interfaces. These options are mutually exclusive.
 
-| Config option | Environment variable | Description |
+| Bind HTTP redirect listener to | `config.json` (`tls` block) | Environment variable |
 | --- | --- | --- |
-| `tls.enabled` | `SEMAPHORE_TLS_ENABLED` | Enables HTTPS for the Semaphore server. |
-| `tls.cert_file` | `SEMAPHORE_TLS_CERT_FILE` | Path to the TLS certificate file. |
-| `tls.key_file` | `SEMAPHORE_TLS_KEY_FILE` | Path to the TLS private key file. |
-| `tls.http_redirect_addr` | `SEMAPHORE_TLS_HTTP_REDIRECT_ADDR` | Optional address for the HTTP-to-HTTPS redirect listener, for example `:80` or `0.0.0.0:80`. This is mutually exclusive with `tls.http_redirect_port`. |
-| `tls.http_redirect_port` | `SEMAPHORE_TLS_HTTP_REDIRECT_PORT` | Port to redirect HTTP traffic to HTTPS. Mutually exclusive with `tls.http_redirect_addr`. |
+| Specific IP address and port | `"http_redirect_addr": "172.29.184.90:80"` | `SEMAPHORE_TLS_HTTP_REDIRECT_ADDR=172.29.184.90:80` |
+| All network interfaces on a port | `"http_redirect_port": 80` | `SEMAPHORE_TLS_HTTP_REDIRECT_PORT=80` |
+
+### Reverse proxy
 
 Alternatively, you can use a reverse proxy in front of Semaphore to handle secure connections. For example:
 

--- a/docs/admin-guide/security/network.md
+++ b/docs/admin-guide/security/network.md
@@ -54,9 +54,9 @@ TLS configuration options:
 
 Alternatively, you can use a reverse proxy in front of Semaphore to handle secure connections. For example:
 
-* [NGINX](/nginx)
-* [Apache](/apache)
-* [Caddy](/caddy)
+* [NGINX](/admin-guide/reverse-proxy/nginx)
+* [Apache](/admin-guide/reverse-proxy/apache)
+* [Caddy](/admin-guide/reverse-proxy/caddy)
  
 
 ### Self-signed SSL certificate

--- a/docs/admin-guide/security/network.md
+++ b/docs/admin-guide/security/network.md
@@ -34,6 +34,21 @@ Semaphore supports SSL/TLS starting from v2.12.
 }
 ```
 
+or:
+
+```json
+{
+    ...
+    "tls": {
+        "enabled": true,
+        "cert_file": "/path/to/cert/example.com.cert",
+        "key_file": "/path/to/key/example.com.key",
+        "http_redirect_port": 80
+    }
+    ...
+}
+```
+
 Or environment variables (useful for Docker):
 
 ```bash
@@ -43,6 +58,15 @@ export SEMAPHORE_TLS_KEY_FILE=/path/to/key/example.com.key
 export SEMAPHORE_TLS_HTTP_REDIRECT_ADDR=80
 ```
 
+or:
+
+```bash
+export SEMAPHORE_TLS_ENABLED=True
+export SEMAPHORE_TLS_CERT_FILE=/path/to/cert/example.com.cert
+export SEMAPHORE_TLS_KEY_FILE=/path/to/key/example.com.key
+export SEMAPHORE_TLS_HTTP_REDIRECT_PORT=80
+```
+
 TLS configuration options:
 
 | Config option | Environment variable | Description |
@@ -50,7 +74,7 @@ TLS configuration options:
 | `tls.enabled` | `SEMAPHORE_TLS_ENABLED` | Enables HTTPS for the Semaphore server. |
 | `tls.cert_file` | `SEMAPHORE_TLS_CERT_FILE` | Path to the TLS certificate file. |
 | `tls.key_file` | `SEMAPHORE_TLS_KEY_FILE` | Path to the TLS private key file. |
-| `tls.http_redirect_addr` | `SEMAPHORE_TLS_HTTP_REDIRECT_ADDR` | Address (`host[:port]`) for the HTTP-to-HTTPS redirect listener. Mutually exclusive with `tls.http_redirect_port`. |
+| `tls.http_redirect_addr` | `SEMAPHORE_TLS_HTTP_REDIRECT_ADDR` | Optional address for the HTTP-to-HTTPS redirect listener, for example `:80` or `0.0.0.0:80`. This is mutually exclusive with `tls.http_redirect_port`. |
 | `tls.http_redirect_port` | `SEMAPHORE_TLS_HTTP_REDIRECT_PORT` | Port to redirect HTTP traffic to HTTPS. Mutually exclusive with `tls.http_redirect_addr`. |
 
 Alternatively, you can use a reverse proxy in front of Semaphore to handle secure connections. For example:


### PR DESCRIPTION
## Summary

- Explain all PingFederate example placeholders, not only `YOUR_ENVIRONMENT_ID`.
- Correct the `tls.http_redirect_addr` examples from `:80` to `80` in the network security docs.

## Validation

- `git diff --check`
- `npm run build`

`npm run build` succeeds. Docusaurus still reports the existing unrelated broken anchor warnings in `/docs/admin-guide/configuration` and `/docs/admin-guide/installation_manually`.